### PR TITLE
Add 'update' method to GlobalTracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ To register a new tracer, based on the current registered tracer, use the `Globa
 ```
 
 This creates a wrapper around the actual underlying `Tracer` implementation.  
-A wrapper around `GlobalTracer` itself should not be registered as that will result in an infinite recursive cycle
-when accessed.
+A wrapper around the `GlobalTracer` singleton itself should not be registered as that will result in 
+an infinite recursive cycle when accessed.
 
 ### Automatic Span propagation
 This library _does not_ manage any span propagation.  

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Global Tracer forwarding to another Tracer implementation.
 Provides the `GlobalTracer.get()` method that returns the singleton _global tracer_.  
 
 When the tracer is needed it is lazily looked up using the following rules:
- 1. The tracer from the last `register(tracer)` call always takes precedence.</li>
+ 1. The tracer from the last `register(tracer)` or `update(tracer -> tracer)` call always takes precedence.</li>
  2. If no tracer was registered, one is looked up from the `ServiceLoader`.  
     The GlobalTracer will not attempt to choose between implementations:
  3. If no single implementation is found, the `NoopTracer` will be used.
@@ -33,6 +33,16 @@ Once initialized, all application code can instrument tracing by starting new sp
 
 If no GlobalTracer is configured, this code will not throw any exceptions.
 Tracing is simply delegated to the `NoopTracer` instead.
+
+### Updating the registered Tracer
+To register a new tracer, based on the current registered tracer, use the `GlobalTracer.update` method:
+```java
+    GlobalTracer.update(tracer -> new WrappingTracer(tracer));
+```
+
+This creates a wrapper around the actual underlying `Tracer` implementation.  
+A wrapper around `GlobalTracer` itself should not be registered as that will result in an infinite recursive cycle
+when accessed.
 
 ### Automatic Span propagation
 This library _does not_ manage any span propagation.  

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -57,7 +57,7 @@ public final class GlobalTracer implements Tracer {
          * <p>
          * This allows updating the {@linkplain GlobalTracer} with a {@linkplain Tracer}
          * that is 'based on' the current registered tracer, allowing delegation or wrapping
-         * tracers to be registered independently from underlying implementaitons.
+         * tracers to be registered independently from underlying implementations.
          *
          * @param current The current GlobalTracer implementation (never <code>null</code>).
          * @return The tracer to become the new GlobalTracer implementation, must be non-null.

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -148,9 +148,6 @@ public final class GlobalTracer implements Tracer {
 
     /**
      * Updates the global tracer using the specified {@link UpdateFunction}.
-     * <p>
-     * Access to the {@linkplain GlobalTracer} is locked during the function,
-     * so make sure the {@linkplain UpdateFunction} is reasonably quick.
      *
      * @param updateFunction The function to update the globaltracer with.
      */
@@ -158,7 +155,7 @@ public final class GlobalTracer implements Tracer {
         if (updateFunction != null) {
             LOCK.lock();
             try {
-                Tracer updated = updateFunction.apply(globalTracer);
+                Tracer updated = updateFunction.apply(lazyTracer());
                 register(requireNonNull(updated, "Updated tracer may not be <null>."));
             } finally {
                 LOCK.unlock();

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -20,8 +20,8 @@ import io.opentracing.propagation.Format;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -84,41 +84,24 @@ public final class GlobalTracer implements Tracer {
      * <p>
      * Access regulated by {@link #LOCK}.
      */
-    private static Tracer globalTracer = null;
-    private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
+    private static volatile Tracer globalTracer = null;
+    private static final Lock LOCK = new ReentrantLock();
 
     private GlobalTracer() {
     }
 
-    // acquires read lock and returns the globalTracer
-    private static Tracer globalTracer() {
-        LOCK.readLock().lock();
-        try {
-            return globalTracer;
-        } finally {
-            LOCK.readLock().unlock();
-        }
-    }
-
     // lazily loading of the globalTracer
     private static Tracer lazyTracer() {
-        LOCK.readLock().lock();
-        try {
-            if (globalTracer == null) {
-                LOCK.readLock().unlock(); // Must release readLock before acquiring writeLock
-                LOCK.writeLock().lock();
-                try {
-                    if (globalTracer == null) globalTracer = loadSingleSpiImplementation();
-                    LOCK.readLock().lock(); // Downgrade by aquiring before releasing writeLock.
-                } finally {
-                    LOCK.writeLock().unlock();
-                }
-                LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", globalTracer);
+        if (globalTracer == null) {
+            LOCK.lock();
+            try {
+                if (globalTracer == null) globalTracer = loadSingleSpiImplementation();
+            } finally {
+                LOCK.unlock();
             }
-            return globalTracer;
-        } finally {
-            LOCK.readLock().unlock();
+            LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", globalTracer);
         }
+        return globalTracer;
     }
 
     /**
@@ -149,15 +132,15 @@ public final class GlobalTracer implements Tracer {
     public static Tracer register(final Tracer tracer) {
         if (tracer instanceof GlobalTracer) {
             LOGGER.log(Level.FINE, "Attempted to register the GlobalTracer as delegate of itself.");
-            return globalTracer(); // no-op, return 'previous' tracer.
+            return globalTracer; // no-op, return 'previous' tracer.
         }
         Tracer previous;
-        LOCK.writeLock().lock();
+        LOCK.lock();
         try {
             previous = globalTracer;
             globalTracer = tracer;
         } finally {
-            LOCK.writeLock().unlock();
+            LOCK.unlock();
         }
         LOGGER.log(Level.INFO, "Registered GlobalTracer {0} (previously {1}).", new Object[]{tracer, previous});
         return previous;
@@ -173,12 +156,12 @@ public final class GlobalTracer implements Tracer {
      */
     public static void update(UpdateFunction updateFunction) {
         if (updateFunction != null) {
-            LOCK.writeLock().lock();
+            LOCK.lock();
             try {
                 Tracer updated = updateFunction.apply(globalTracer);
                 register(requireNonNull(updated, "Updated tracer may not be <null>."));
             } finally {
-                LOCK.writeLock().unlock();
+                LOCK.unlock();
             }
         }
     }

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -20,7 +20,8 @@ import io.opentracing.propagation.Format;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -80,23 +81,44 @@ public final class GlobalTracer implements Tracer {
      * This can be either an {@link #register(Tracer) explicitly registered} or
      * the {@link #loadSingleSpiImplementation() automatically resolved} Tracer
      * (or <code>null</code> during initialization).
+     * <p>
+     * Access regulated by {@link #LOCK}.
      */
-    private final AtomicReference<Tracer> globalTracer = new AtomicReference<Tracer>();
+    private static Tracer globalTracer = null;
+    private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
 
     private GlobalTracer() {
     }
 
-    private Tracer lazyTracer() {
-        Tracer tracer = globalTracer.get();
-        if (tracer == null) {
-            final Tracer resolved = loadSingleSpiImplementation();
-            while (tracer == null && resolved != null) { // handle rare race condition
-                globalTracer.compareAndSet(null, resolved);
-                tracer = globalTracer.get();
-            }
-            LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", tracer);
+    // acquires read lock and returns the globalTracer
+    private static Tracer globalTracer() {
+        LOCK.readLock().lock();
+        try {
+            return globalTracer;
+        } finally {
+            LOCK.readLock().unlock();
         }
-        return tracer;
+    }
+
+    // lazily loading of the globalTracer
+    private static Tracer lazyTracer() {
+        LOCK.readLock().lock();
+        try {
+            if (globalTracer == null) {
+                LOCK.readLock().unlock(); // Must release readLock before acquiring writeLock
+                LOCK.writeLock().lock();
+                try {
+                    if (globalTracer == null) globalTracer = loadSingleSpiImplementation();
+                    LOCK.readLock().lock(); // Downgrade by aquiring before releasing writeLock.
+                } finally {
+                    LOCK.writeLock().unlock();
+                }
+                LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", globalTracer);
+            }
+            return globalTracer;
+        } finally {
+            LOCK.readLock().unlock();
+        }
     }
 
     /**
@@ -127,9 +149,16 @@ public final class GlobalTracer implements Tracer {
     public static Tracer register(final Tracer tracer) {
         if (tracer instanceof GlobalTracer) {
             LOGGER.log(Level.FINE, "Attempted to register the GlobalTracer as delegate of itself.");
-            return INSTANCE.globalTracer.get(); // no-op, return 'previous' tracer.
+            return globalTracer(); // no-op, return 'previous' tracer.
         }
-        Tracer previous = INSTANCE.globalTracer.getAndSet(tracer);
+        Tracer previous;
+        LOCK.writeLock().lock();
+        try {
+            previous = globalTracer;
+            globalTracer = tracer;
+        } finally {
+            LOCK.writeLock().unlock();
+        }
         LOGGER.log(Level.INFO, "Registered GlobalTracer {0} (previously {1}).", new Object[]{tracer, previous});
         return previous;
     }
@@ -137,27 +166,20 @@ public final class GlobalTracer implements Tracer {
     /**
      * Updates the global tracer using the specified {@link UpdateFunction}.
      * <p>
-     * If the update encounters a race condition, the 'losing' update function is re-applied with the 'winning' tracer.
-     * To avoid concurrency 'hotspins', please make sure the {@linkplain UpdateFunction} is reasonably quick.
-     * <p>
-     * If there are concurrent modifications of the globaltracer (e.g. by a race-condition with a call to
-     * {@link #register(Tracer) register}, the update function will be)
+     * Access to the {@linkplain GlobalTracer} is locked during the function,
+     * so make sure the {@linkplain UpdateFunction} is reasonably quick.
      *
-     * @param updateFunction The function to update the globaltracer implementation with.
+     * @param updateFunction The function to update the globaltracer with.
      */
     public static void update(UpdateFunction updateFunction) {
         if (updateFunction != null) {
-            Tracer current, updated;
-            do {
-                current = INSTANCE.lazyTracer();
-                updated = updateFunction.apply(current);
-                if (updated == null) throw new NullPointerException("Updated tracer may not be <null>.");
-                else if (updated instanceof GlobalTracer) {
-                    LOGGER.log(Level.FINE, "Attempted to update the GlobalTracer with itself.");
-                    return;
-                }
-            } while (!INSTANCE.globalTracer.compareAndSet(current, updated)); // 'while' handles race condition.
-            LOGGER.log(Level.INFO, "Updated GlobalTracer {0} (previously {1}).", new Object[]{updated, current});
+            LOCK.writeLock().lock();
+            try {
+                Tracer updated = updateFunction.apply(globalTracer);
+                register(requireNonNull(updated, "Updated tracer may not be <null>."));
+            } finally {
+                LOCK.writeLock().unlock();
+            }
         }
     }
 
@@ -194,6 +216,12 @@ public final class GlobalTracer implements Tracer {
                     "Falling back to NoopTracer implementation.");
         }
         return NoopTracerFactory.create();
+    }
+
+    // Similar to java 7 Objects.requireNonNull
+    private static <T> T requireNonNull(T value, String message) {
+        if (value == null) throw new NullPointerException(message);
+        return value;
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/global/ConcurrentAccessTest.java
+++ b/src/test/java/io/opentracing/contrib/global/ConcurrentAccessTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.global;
+
+import io.opentracing.NoopTracer;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.opentracing.contrib.global.GlobalTracerTest.sleepRandom;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class ConcurrentAccessTest {
+
+    Tracer previousGlobalTracer;
+
+    @Before
+    public void setup() {
+        previousGlobalTracer = GlobalTracer.register(null); // Reset lazy state and remember previous tracer.
+    }
+
+    @After
+    public void teardown() {
+        GlobalTracer.register(previousGlobalTracer instanceof NoopTracer ? null : previousGlobalTracer);
+    }
+
+    @Test
+    public void testConcurrent_readWrites() throws InterruptedException {
+        final MockTracer original = new MockTracer();
+        GlobalTracer.register(original);
+
+        final int count = 10;
+        final Thread[] threads = new Thread[3 * count];
+
+        // Threads re-registration of original
+        for (int i = 0; i < count; i++)
+            threads[i] = new Thread() {
+                public void run() {
+                    sleepRandom(100);
+                    GlobalTracer.register(original);
+                }
+            };
+        // Threads adding trivial wrappers
+        for (int i = count; i < 2 * count; i++) {
+            threads[i] = new Thread() {
+                public void run() {
+                    GlobalTracer.update(TrivialWrappingTracer.WRAP);
+                }
+            };
+        }
+        for (int i = 2 * count; i < 3 * count; i++) {
+            threads[i] = new Thread() {
+                public void run() {
+                    Span span = GlobalTracer.get().buildSpan("operation").start();
+                    sleepRandom(100);
+                    span.close();
+                }
+            };
+        }
+
+        // Start threads & wait for completion
+        Collections.shuffle(asList(threads));
+        for (Thread t : threads) t.start();
+        for (Thread t : threads) t.join(1000);
+
+        assertThat(original.finishedSpans(), hasSize(count));
+        for (MockSpan span : original.finishedSpans()) {
+            assertThat(span.operationName(), is("operation"));
+        }
+    }
+
+}

--- a/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
+++ b/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Random;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -198,4 +199,14 @@ public class GlobalTracerTest {
         return count;
     }
 
+    private static final Random RND = new Random();
+
+    static void sleepRandom(int maxmillis) {
+        try {
+            Thread.sleep(RND.nextInt(maxmillis));
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(ie.getMessage(), ie);
+        }
+    }
 }

--- a/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
+++ b/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
@@ -47,7 +47,7 @@ final class TrivialWrappingTracer implements Tracer {
     final Tracer wrapped;
 
     TrivialWrappingTracer(Tracer delegate) {
-        if (delegate == null) throw new NullPointerException("Cannor wrap <null> Tracer.");
+        if (delegate == null) throw new NullPointerException("Cannot wrap <null> Tracer.");
         this.wrapped = delegate;
         LOGGER.log(Level.FINE, "New {0} created.", this);
     }

--- a/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
+++ b/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
@@ -23,6 +23,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static io.opentracing.contrib.global.GlobalTracerTest.sleepRandom;
+
 /**
  * A 'trivial' wrapping tracer that delegates all calls as-is.
  */
@@ -33,13 +35,9 @@ final class TrivialWrappingTracer implements Tracer {
     static final GlobalTracer.UpdateFunction WRAP = new GlobalTracer.UpdateFunction() {
         @Override
         public Tracer apply(Tracer current) {
-            try {
-                Tracer newWrapper = new TrivialWrappingTracer(current);
-                Thread.sleep(100);
-                return newWrapper;
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e.getMessage(), e);
-            }
+            Tracer newWrapper = new TrivialWrappingTracer(current);
+            sleepRandom(100);
+            return newWrapper;
         }
     };
 

--- a/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
+++ b/src/test/java/io/opentracing/contrib/global/TrivialWrappingTracer.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.global;
+
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A 'trivial' wrapping tracer that delegates all calls as-is.
+ */
+final class TrivialWrappingTracer implements Tracer {
+    private static final Logger LOGGER = Logger.getLogger(TrivialWrappingTracer.class.getName());
+    static final AtomicInteger SEQUENCER = new AtomicInteger(0);
+
+    static final GlobalTracer.UpdateFunction WRAP = new GlobalTracer.UpdateFunction() {
+        @Override
+        public Tracer apply(Tracer current) {
+            try {
+                Tracer newWrapper = new TrivialWrappingTracer(current);
+                Thread.sleep(100);
+                return newWrapper;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e.getMessage(), e);
+            }
+        }
+    };
+
+    final int nr = SEQUENCER.incrementAndGet();
+    final Tracer wrapped;
+
+    TrivialWrappingTracer(Tracer delegate) {
+        if (delegate == null) throw new NullPointerException("Cannor wrap <null> Tracer.");
+        this.wrapped = delegate;
+        LOGGER.log(Level.FINE, "New {0} created.", this);
+    }
+
+    @Override
+    public SpanBuilder buildSpan(String operationName) {
+        return wrapped.buildSpan(operationName);
+    }
+
+    @Override
+    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+        wrapped.inject(spanContext, format, carrier);
+    }
+
+    @Override
+    public <C> SpanContext extract(Format<C> format, C carrier) {
+        return wrapped.extract(format, carrier);
+    }
+
+    List<Tracer> flatten() {
+        List<Tracer> flatList = new ArrayList<Tracer>();
+        flatList.add(this);
+        if (wrapped instanceof TrivialWrappingTracer) {
+            flatList.addAll(((TrivialWrappingTracer) wrapped).flatten());
+        } else {
+            flatList.add(wrapped);
+        }
+        return flatList;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{nr=" + nr + ", wrapped=" + wrapped + '}';
+    }
+
+}


### PR DESCRIPTION
This PR is intended to extend the `GlobalTracer` API with an `update(Tracer -> Tracer)` method to be able to register a `Tracer` implementation _based on the currently registered Tracer_.

The most obvious use-case for this is when someone wants to wrap the currently registered Tracer, for example: Mechanism to handle "wrapper" Tracers (#7).
This is currently not possible to do in a thread-safe manner.