### PR TITLE
Deprecate contrib GlobalTracer and forward to OpenTracing-java util.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <build.java.version>1.6</build.java.version>
 
-        <opentracing-api.version>0.20.10</opentracing-api.version>
+        <opentracing-api.version>0.21.0</opentracing-api.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
@@ -98,6 +98,11 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-noop</artifactId>
+            <version>${opentracing-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-util</artifactId>
             <version>${opentracing-api.version}</version>
         </dependency>
 

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -55,12 +55,12 @@ public final class GlobalTracer {
             if (!(resolved instanceof NoopTracer)) {
                 try {
                     io.opentracing.util.GlobalTracer.register(resolved);
+                    LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", resolved);
                 } catch (RuntimeException alreadyRegistered) {
                     LOGGER.log(Level.WARNING, "Could not automatically register " + resolved + " because: "
                             + alreadyRegistered.getMessage(), alreadyRegistered);
                 }
             }
-            LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", resolved);
         }
     }
 

--- a/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
+++ b/src/main/java/io/opentracing/contrib/global/GlobalTracer.java
@@ -13,14 +13,14 @@
  */
 package io.opentracing.contrib.global;
 
+import io.opentracing.NoopTracer;
 import io.opentracing.NoopTracerFactory;
-import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
-import io.opentracing.propagation.Format;
 
+import java.lang.reflect.Field;
 import java.util.Iterator;
 import java.util.ServiceLoader;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,43 +38,26 @@ import java.util.logging.Logger;
  * The {@linkplain GlobalTracer} will not attempt to choose between implementations:</li>
  * <li>If no single tracer service is found, the {@link io.opentracing.NoopTracer NoopTracer} will be used.</li>
  * </ol>
+ *
+ * @see io.opentracing.util.GlobalTracer
+ * @deprecated GlobalTracer is now part of OpenTracing-java
  */
-public final class GlobalTracer implements Tracer {
+public final class GlobalTracer {
     private static final Logger LOGGER = Logger.getLogger(GlobalTracer.class.getName());
 
-    /**
-     * Singleton instance.
-     * <p>
-     * Since we cannot prevent people using {@linkplain #get() GlobalTracer.get()} as a constant,
-     * this guarantees that references obtained before, during or after initialization
-     * all behave as if obtained <em>after</em> initialization once properly initialized.<br>
-     * As a minor additional benefit it makes it harder to circumvent the {@link Tracer} API.
-     */
-    private static final GlobalTracer INSTANCE = new GlobalTracer();
-
-    /**
-     * The resolved {@link Tracer} to delegate to.
-     * <p>
-     * This can be either an {@link #register(Tracer) explicitly registered} or
-     * the {@link #loadSingleSpiImplementation() automatically resolved} Tracer
-     * (or <code>null</code> during initialization).
-     */
-    private final AtomicReference<Tracer> globalTracer = new AtomicReference<Tracer>();
+    private static final AtomicBoolean SINGLE_INIT = new AtomicBoolean(false);
 
     private GlobalTracer() {
     }
 
-    private Tracer lazyTracer() {
-        Tracer tracer = globalTracer.get();
-        if (tracer == null) {
+    private static void lazyInit() {
+        if (SINGLE_INIT.compareAndSet(false, true) && tryReflectCurrent() instanceof NoopTracer) {
             final Tracer resolved = loadSingleSpiImplementation();
-            while (tracer == null && resolved != null) { // handle rare race condition
-                globalTracer.compareAndSet(null, resolved);
-                tracer = globalTracer.get();
+            if (!(resolved instanceof NoopTracer)) {
+                io.opentracing.util.GlobalTracer.register(resolved);
             }
-            LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", tracer);
+            LOGGER.log(Level.INFO, "Using GlobalTracer: {0}.", resolved);
         }
-        return tracer;
     }
 
     /**
@@ -88,10 +71,30 @@ public final class GlobalTracer implements Tracer {
      * For example, the tracer used to extract a span may be different than the one that injects it.
      *
      * @return The global tracer constant.
-     * @see #register(Tracer)
+     * @see io.opentracing.util.GlobalTracer#get()
+     * @deprecated Please use GlobalTracer from opentracing-util instead.
      */
     public static Tracer get() {
-        return INSTANCE;
+        lazyInit();
+        return io.opentracing.util.GlobalTracer.get();
+    }
+
+    private static Tracer tryReflectCurrent() {
+        Tracer current = null;
+        try {
+            Field tracerFld = io.opentracing.util.GlobalTracer.class.getDeclaredField("tracer");
+            synchronized (tracerFld) {
+                tracerFld.setAccessible(true);
+                try {
+                    current = (Tracer) tracerFld.get(null);
+                } finally {
+                    tracerFld.setAccessible(false);
+                }
+            }
+        } catch (Exception reflectionError) {
+
+        }
+        return current;
     }
 
     /**
@@ -103,28 +106,10 @@ public final class GlobalTracer implements Tracer {
      * @return The previous global tracer or <code>null</code> if there was none.
      */
     public static Tracer register(final Tracer tracer) {
-        if (tracer instanceof GlobalTracer) {
-            LOGGER.log(Level.FINE, "Attempted to register the GlobalTracer as delegate of itself.");
-            return INSTANCE.globalTracer.get(); // no-op, return 'previous' tracer.
-        }
-        Tracer previous = INSTANCE.globalTracer.getAndSet(tracer);
+        final Tracer previous = tryReflectCurrent();
+        io.opentracing.util.GlobalTracer.register(tracer);
         LOGGER.log(Level.INFO, "Registered GlobalTracer {0} (previously {1}).", new Object[]{tracer, previous});
         return previous;
-    }
-
-    @Override
-    public SpanBuilder buildSpan(String operationName) {
-        return lazyTracer().buildSpan(operationName);
-    }
-
-    @Override
-    public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
-        lazyTracer().inject(spanContext, format, carrier);
-    }
-
-    @Override
-    public <C> SpanContext extract(Format<C> format, C carrier) {
-        return lazyTracer().extract(format, carrier);
     }
 
     /**

--- a/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
+++ b/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings("deprecation") // Test is for a deprecated class.
 public class GlobalTracerTest {
 
     @Before
@@ -37,8 +38,8 @@ public class GlobalTracerTest {
         Field tracerFld = io.opentracing.util.GlobalTracer.class.getDeclaredField("tracer");
         Field singleInit = GlobalTracer.class.getDeclaredField("SINGLE_INIT");
         synchronized (tracerFld) {
-            tracerFld.setAccessible(true);
             singleInit.setAccessible(true);
+            tracerFld.setAccessible(true);
             try {
                 tracerFld.set(null, NoopTracerFactory.create());
                 ((AtomicBoolean) singleInit.get(null)).set(false);
@@ -98,17 +99,6 @@ public class GlobalTracerTest {
         verify(t1).buildSpan(eq("first operation"));
         verify(t1).buildSpan(eq("second operation"));
         verifyNoMoreInteractions(t1);
-    }
-
-    /**
-     * Registering the GlobalTracer as its own delegate should be a no-op.
-     */
-    @Test
-    public void testRegister_GlobalTracerAsItsOwnDelegate() {
-        Tracer result1 = GlobalTracer.register(GlobalTracer.get());
-        Tracer result2 = GlobalTracer.register(GlobalTracer.get());
-        assertThat(result1, is(instanceOf(MockTracer.class))); // get() triggered lazy init
-        assertThat(result2, is(sameInstance(result2)));
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
+++ b/src/test/java/io/opentracing/contrib/global/GlobalTracerTest.java
@@ -14,12 +14,15 @@
 package io.opentracing.contrib.global;
 
 import io.opentracing.NoopSpanBuilder;
-import io.opentracing.NoopTracer;
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockTracer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -28,22 +31,44 @@ import static org.mockito.Mockito.*;
 
 public class GlobalTracerTest {
 
-    Tracer previousGlobalTracer;
-
     @Before
-    public void setup() {
-        previousGlobalTracer = GlobalTracer.register(null); // Reset lazy state and remember previous tracer.
+    @After
+    public void unregisterGlobalTracer() throws Exception {
+        Field tracerFld = io.opentracing.util.GlobalTracer.class.getDeclaredField("tracer");
+        Field singleInit = GlobalTracer.class.getDeclaredField("SINGLE_INIT");
+        synchronized (tracerFld) {
+            tracerFld.setAccessible(true);
+            singleInit.setAccessible(true);
+            try {
+                tracerFld.set(null, NoopTracerFactory.create());
+                ((AtomicBoolean) singleInit.get(null)).set(false);
+            } finally {
+                tracerFld.setAccessible(false);
+                singleInit.setAccessible(false);
+            }
+        }
     }
 
-    @After
-    public void teardown() {
-        GlobalTracer.register(previousGlobalTracer instanceof NoopTracer ? null : previousGlobalTracer);
+    private static Tracer globalTracerInstance() {
+        try {
+            Field tracerFld = io.opentracing.util.GlobalTracer.class.getDeclaredField("tracer");
+            synchronized (tracerFld) {
+                tracerFld.setAccessible(true);
+                try {
+                    return (Tracer) tracerFld.get(null);
+                } finally {
+                    tracerFld.setAccessible(false);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
     public void testGet_SingletonReference() {
         Tracer tracer = GlobalTracer.get();
-        assertThat(tracer, is(instanceOf(GlobalTracer.class)));
+        assertThat(tracer, is(instanceOf(io.opentracing.util.GlobalTracer.class)));
         assertThat(tracer, is(sameInstance(GlobalTracer.get())));
     }
 
@@ -54,33 +79,8 @@ public class GlobalTracerTest {
     @Test
     public void testGet_AutomaticServiceLoading() {
         GlobalTracer.get().buildSpan("some operation"); // triggers lazy tracer resolution.
-        Tracer resolvedTracer = GlobalTracer.register(null); // clear again, returning current (auto-resolved) tracer.
+        Tracer resolvedTracer = globalTracerInstance();
         assertThat("Resolved Tracer service", resolvedTracer, is(instanceOf(MockTracer.class)));
-    }
-
-    @Test
-    public void testGet_AutomaticServiceLoading_Concurrent() throws InterruptedException {
-        int threadCount = 10;
-        Thread[] threads = new Thread[threadCount];
-        final Tracer[] resolvedTracers = new Tracer[threadCount];
-        for (int i = 0; i < threadCount; i++) {
-            final int idx = i;
-            threads[i] = new Thread() {
-                @Override
-                public void run() {
-                    GlobalTracer.get().buildSpan("some operation"); // trigger lazy tracer resolution.
-                    resolvedTracers[idx] = GlobalTracer.register(GlobalTracer.get()); // no-op returning tracer
-                }
-            };
-        }
-
-        assertThat("Nothing happened yet", identityCount(null, resolvedTracers), is(threadCount));
-        // Start threads & wait for completion
-        for (int i = 0; i < threadCount; i++) threads[i].start();
-        for (int i = 0; i < threadCount; i++) threads[i].join(1000);
-
-        assertThat("Resolved tracer", resolvedTracers[0], is(instanceOf(MockTracer.class)));
-        assertThat("Resolved identical in all threads", identityCount(resolvedTracers[0], resolvedTracers), is(threadCount));
     }
 
     /**
@@ -88,22 +88,16 @@ public class GlobalTracerTest {
      */
     @Test
     public void testGet_AfterRegister() {
-        GlobalTracer.get().buildSpan("some operation"); // trigger lazy tracer service loading.
-        Tracer t1 = mock(Tracer.class), t2 = mock(Tracer.class);
+        Tracer t1 = mock(Tracer.class);
         when(t1.buildSpan(anyString())).thenReturn(NoopSpanBuilder.INSTANCE);
-        when(t2.buildSpan(anyString())).thenReturn(NoopSpanBuilder.INSTANCE);
 
         GlobalTracer.register(t1);
         GlobalTracer.get().buildSpan("first operation");
         GlobalTracer.get().buildSpan("second operation");
 
-        assertThat(GlobalTracer.register(t2), is(sameInstance(t1)));
-        GlobalTracer.get().buildSpan("third operation");
-
         verify(t1).buildSpan(eq("first operation"));
         verify(t1).buildSpan(eq("second operation"));
-        verify(t2).buildSpan(eq("third operation"));
-        verifyNoMoreInteractions(t1, t2);
+        verifyNoMoreInteractions(t1);
     }
 
     /**
@@ -113,48 +107,8 @@ public class GlobalTracerTest {
     public void testRegister_GlobalTracerAsItsOwnDelegate() {
         Tracer result1 = GlobalTracer.register(GlobalTracer.get());
         Tracer result2 = GlobalTracer.register(GlobalTracer.get());
-        assertThat(result1, is(sameInstance(previousGlobalTracer)));
-        assertThat(result2, is(sameInstance(previousGlobalTracer)));
-    }
-
-    @Test
-    public void testRegister_ConcurrentThreads() throws InterruptedException {
-        final int threadCount = 10;
-        final Tracer[] tracers = new Tracer[threadCount];
-        final Tracer[] previous = new Tracer[threadCount];
-        Thread[] threads = new Thread[threadCount];
-
-        for (int i = 0; i < threadCount; i++) tracers[i] = mock(Tracer.class);
-        for (int i = 0; i < threadCount; i++) {
-            final int idx = i;
-            threads[idx] = new Thread() {
-                @Override
-                public void run() {
-                    previous[idx] = GlobalTracer.register(tracers[idx]);
-                }
-            };
-        }
-
-        assertThat("Nothing happened yet", identityCount(null, previous), is(threadCount));
-        // Start threads & wait for completion
-        for (int i = 0; i < threadCount; i++) threads[i].start();
-        for (int i = 0; i < threadCount; i++) threads[i].join(1000);
-
-        assertThat("Previous of first is null", identityCount(null, previous), is(1));
-        final Tracer last = GlobalTracer.register(null); // last-register tracer ('previous' of new tracer null).
-        assertThat("Last must be from tracers", identityCount(last, tracers), is(1));
-        assertThat("Last is no previous tracer", identityCount(last, previous), is(0));
-        for (int i = 0; i < threadCount; i++) {
-            if (last != tracers[i]) { // All non-last tracers should be previous exactly once!
-                assertThat("Occurrences in previous", identityCount(tracers[i], previous), is(1));
-            }
-        }
-    }
-
-    private static int identityCount(Tracer needle, Tracer... haystack) {
-        int count = 0;
-        for (Tracer t : haystack) if (t == needle) count++;
-        return count;
+        assertThat(result1, is(instanceOf(MockTracer.class))); // get() triggered lazy init
+        assertThat(result2, is(sameInstance(result2)));
     }
 
 }


### PR DESCRIPTION
`GlobalTracer` is now included in OpenTracing-java in the `util` module.
The package is also changed to `io.opentracing.util` and the `register()` method has become an _only-once_ method.

The `io.opentracing.global.GlobalTracer` implementation returns the util GlobalTracer and no longer actually _implements Tracer_. It has been made \@deprecated to alert people of this.

The auto-loading via the `ServiceLoader` will be triggered by the now deprecated `get()` method.